### PR TITLE
Enable travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,9 @@ env:
   - JAVAVER="openjdk18-devel"
 services:
   - docker
+before_install:
+  - sudo apt-get update
+  - sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" docker-engine
+
 script:
     - docker build --build-arg JAVAVER=$JAVAVER -t devslave-c7-test .

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: python
+env:
+  - JAVAVER="oracle17"
+  - JAVAVER="oracle18"
+  - JAVAVER="openjdk17"
+  - JAVAVER="openjdk18"
+  - JAVAVER="openjdk17-devel"
+  - JAVAVER="openjdk18-devel"
+services:
+  - docker
+script:
+    - docker build --build-arg JAVAVER=$JAVAVER -t devslave-c7-test .


### PR DESCRIPTION
Like apacheds-docker, this simply shows that a build
command works. The build, however, is run on all the
Java versions to be found in omero-install.

See: https://github.com/ome/omero-install/pull/94
