### PR TITLE
slave node uses systemd

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,34 @@
-language: python
+sudo: required
+
+language: java
+
+services:
+  - docker
+
+
 env:
+  global:
+    - DOCKER_VERSION=1.10.1-0~trusty
   - JAVAVER="oracle17"
   - JAVAVER="oracle18"
   - JAVAVER="openjdk17"
   - JAVAVER="openjdk18"
   - JAVAVER="openjdk17-devel"
   - JAVAVER="openjdk18-devel"
-services:
-  - docker
+  - EXE4J_VERSION="5_1"
+  - JENKINS_SWARM_VERSION="1.24"
+  - JENKINS_SWARM_VERSION="2.0"
+
 before_install:
   - sudo apt-get update
-  - sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" docker-engine
+  - sudo DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confnew" install docker-engine=${DOCKER_VERSION}
+  - docker -v
+
+install:
+  - make BUILDARGS="--build-arg JAVAVER=$JAVAVER --build-arg EXE4J_VERSION=$EXE4J_VERSION --build-arg JENKINS_SWARM_VERSION=$JENKINS_SWARM_VERSION"
 
 script:
-    - docker build --build-arg JAVAVER=$JAVAVER -t devslave-c7-test .
+  - make start VOLUME="-v /sys/fs/cgroup:/sys/fs/cgroup:ro -v /run"
+  - docker inspect -f {{.State.Running}} devslave
+  - make stop
+  - make rm

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ services:
 
 
 env:
-  global:
-    - DOCKER_VERSION=1.10.1-0~trusty
   - JAVAVER="oracle17"
   - JAVAVER="oracle18"
   - JAVAVER="openjdk17"
@@ -21,7 +19,7 @@ env:
 
 before_install:
   - sudo apt-get update
-  - sudo DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confnew" install docker-engine=${DOCKER_VERSION}
+  - sudo DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confnew" install docker-engine
   - docker -v
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,16 @@ install:
   - make BUILDARGS="--build-arg JAVAVER=$JAVAVER"
 
 script:
-  - make start VOLUME="-v /sys/fs/cgroup:/sys/fs/cgroup:ro -v /run"
+  - docker run -d --name jenkins jenkins
+  - docker inspect -f {{.State.Running}} jenkins
+  - while ! docker logs jenkins 2>&1 | grep "Jenkins is fully up and running" ; do sleep 10; done
+  - JENKINS_ADDR=`docker inspect --format '{{ .NetworkSettings.IPAddress }}' jenkins`
+  - JENKINS_PORT=50000
+  - make start ENV="-e JENKINS_PORT_8080_TCP_ADDR=$JENKINS_ADDR -e JENKINS_PORT_8080_TCP_PORT=$JENKINS_PORT" VOLUMES="-v /sys/fs/cgroup:/sys/fs/cgroup:ro -v /run"
   - docker inspect -f {{.State.Running}} devslave
+  - SLAVE_ADDR=`docker inspect --format '{{ .NetworkSettings.IPAddress }}' devslave`
+  - while ! docker logs jenkins 2>&1 | grep "from /${SLAVE_ADDR}" ; do sleep 10; done
   - docker exec -it devslave /bin/bash -c "service jenkins status -l"
+  - docker logs jenkins
   - make stop
   - make rm

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ language: java
 services:
   - docker
 
-
 env:
   - JAVAVER="oracle17"
   - JAVAVER="oracle18"
@@ -13,6 +12,7 @@ env:
   - JAVAVER="openjdk18"
   - JAVAVER="openjdk17-devel"
   - JAVAVER="openjdk18-devel"
+  - EXE4J_VERSION="5_0_1"
   - EXE4J_VERSION="5_1"
   - JENKINS_SWARM_VERSION="1.24"
   - JENKINS_SWARM_VERSION="2.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,6 @@ env:
   - JAVAVER="openjdk18"
   - JAVAVER="openjdk17-devel"
   - JAVAVER="openjdk18-devel"
-  - EXE4J_VERSION="5_0_1"
-  - EXE4J_VERSION="5_1"
-  - JENKINS_SWARM_VERSION="1.24"
-  - JENKINS_SWARM_VERSION="2.0"
 
 before_install:
   - sudo apt-get update
@@ -23,7 +19,7 @@ before_install:
   - docker -v
 
 install:
-  - make BUILDARGS="--build-arg JAVAVER=$JAVAVER --build-arg EXE4J_VERSION=$EXE4J_VERSION --build-arg JENKINS_SWARM_VERSION=$JENKINS_SWARM_VERSION"
+  - make BUILDARGS="--build-arg JAVAVER=$JAVAVER"
 
 script:
   - make start VOLUME="-v /sys/fs/cgroup:/sys/fs/cgroup:ro -v /run"

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,13 +24,13 @@ install:
 script:
   - docker run -d --name jenkins jenkins
   - docker inspect -f {{.State.Running}} jenkins
-  - while ! docker logs jenkins 2>&1 | grep "Jenkins is fully up and running" ; do sleep 10; done
+  - d=10; while ! docker logs jenkins 2>&1 | grep "Jenkins is fully up and running" ; do sleep 10; d=$[$d -1]; if [ $d -lt 0 ]; then exit 1; fi; done
   - JENKINS_ADDR=`docker inspect --format '{{ .NetworkSettings.IPAddress }}' jenkins`
   - JENKINS_PORT=50000
   - make start ENV="-e JENKINS_PORT_8080_TCP_ADDR=$JENKINS_ADDR -e JENKINS_PORT_8080_TCP_PORT=$JENKINS_PORT" VOLUMES="-v /sys/fs/cgroup:/sys/fs/cgroup:ro -v /run"
   - docker inspect -f {{.State.Running}} devslave
   - SLAVE_ADDR=`docker inspect --format '{{ .NetworkSettings.IPAddress }}' devslave`
-  - while ! docker logs jenkins 2>&1 | grep "from /${SLAVE_ADDR}" ; do sleep 10; done
+  - d=10; while ! docker logs jenkins 2>&1 | grep "from /${SLAVE_ADDR}" ; do sleep 10; d=$[$d -1]; if [ $d -lt 0 ]; then exit 1; fi; done
   - docker exec -it devslave /bin/bash -c "service jenkins status -l"
   - docker logs jenkins
   - make stop

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,5 +24,6 @@ install:
 script:
   - make start VOLUME="-v /sys/fs/cgroup:/sys/fs/cgroup:ro -v /run"
   - docker inspect -f {{.State.Running}} devslave
+  - docker exec -it devslave /bin/bash -c "service jenkins status -l"
   - make stop
   - make rm

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN yum install -y git \
     && yum clean all
 
 RUN git clone https://github.com/ome/omero-install.git /tmp/omero-install
+RUN bash $OMERO_INSTALL/step01_centos7_init.sh
 RUN bash $OMERO_INSTALL/step01_centos_java_deps.sh
 
 RUN yum install -y http://download-keycdn.ej-technologies.com/exe4j/exe4j_linux_$EXE4J_VERSION.rpm \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,9 @@ RUN yum install -y initscripts \
 
 RUN chmod a+X /home/omero
 
-ARG JAVAVER=openjdk18
-ARG EXE4J_VERSION=5_0_1
-ARG JENKINS_SWARM_VERSION=2.0
+ARG JAVAVER=${JAVAVER:-openjdk18}
+ARG EXE4J_VERSION=${EXE4J_VERSION:-5_1}
+ARG JENKINS_SWARM_VERSION=${JENKINS_SWARM_VERSION:-2.0}
 
 # Download and run omero-install.
 ENV OMERO_INSTALL /tmp/omero-install/linux

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ FROM openmicroscopy/omero-ssh-systemd
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 ENV LANG en_US.UTF-8
-ENV JENKINS_LABEL /etc/alternatives/java_sdk
 ENV JENKINS_MODE exclusive
 
 ENV SWARM_PARAMS "'-labels slave -executors 1'"

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,5 +44,3 @@ ADD ./jenkins-slave.sh /tmp/jenkins-slave.sh
 RUN chmod +x /tmp/jenkins-slave.sh
 ADD ./jenkins.service /etc/systemd/system/jenkins.service
 RUN systemctl enable jenkins.service
-
-#ENTRYPOINT ["/tmp/jenkins-slave.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,49 @@
 FROM openmicroscopy/omero-ssh-systemd
+
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
-ENV JENKINS_SWARM_VERSION 1.24
 ENV LANG en_US.UTF-8
-ARG JAVAVER=openjdk18
+ENV JENKINS_LABEL /etc/alternatives/java_sdk
+ENV JENKINS_MODE exclusive
+
+ENV SWARM_PARAMS "'-labels slave -executors 1'"
 
 # To avoid error: sudo: sorry, you must have a tty to run sudo
 RUN sed -i -e "s/Defaults    requiretty.*/ #Defaults    requiretty/g" /etc/sudoers
 
-# Download and run omero-install. This section can be customized
-# by running particular scripts from any omero-install install*.sh
-# script.
+#RUN usermod -u $UID omero
+
+WORKDIR /home/omero
+
+RUN yum install -y initscripts \
+    && yum clean all
+
+RUN chmod a+X /home/omero
+
+ARG JAVAVER=openjdk18
+ARG EXE4J_VERSION=5_0_1
+ARG JENKINS_SWARM_VERSION=2.0
+
+# Download and run omero-install.
 ENV OMERO_INSTALL /tmp/omero-install/linux
-#RUN git clone git://github.com/ome/omero-install /tmp/omero-install
-RUN yum install -y git && \
-    git clone -b java-parameters git://github.com/jburel/omero-install /tmp/omero-install && \
-    source $OMERO_INSTALL/settings.env && \
-    bash $OMERO_INSTALL/step01_centos7_init.sh && \
-    bash $OMERO_INSTALL/step01_centos_java_deps.sh && \
-    bash $OMERO_INSTALL/step01_centos7_deps.sh && \
-    bash $OMERO_INSTALL/step02_all_setup.sh && \
-    echo skip step3/pg since external and step4/omero and step5/nginx since run by job && \
-    yum install -y http://download-aws.ej-technologies.com/exe4j/exe4j_linux_5_0_1.rpm
 
-WORKDIR /tmp
-RUN curl --create-dirs -sSLo /tmp/swarm-client-$JENKINS_SWARM_VERSION-jar-with-dependencies.jar \
-    http://maven.jenkins-ci.org/content/repositories/releases/org/jenkins-ci/plugins/swarm-client/$JENKINS_SWARM_VERSION/swarm-client-$JENKINS_SWARM_VERSION-jar-with-dependencies.jar
+RUN yum install -y git \
+    && yum clean all
 
-COPY jenkins-slave.sh /tmp/jenkins-slave.sh
-COPY jenkins.service /etc/systemd/system
+RUN git clone https://github.com/ome/omero-install.git /tmp/omero-install
+RUN bash $OMERO_INSTALL/step01_centos_java_deps.sh
 
+RUN yum install -y http://download-keycdn.ej-technologies.com/exe4j/exe4j_linux_$EXE4J_VERSION.rpm \
+    && yum clean all
+
+USER omero
+RUN curl --create-dirs -sSLo /tmp/swarm-client-$JENKINS_SWARM_VERSION-jar-with-dependencies.jar http://maven.jenkins-ci.org/content/repositories/releases/org/jenkins-ci/plugins/swarm-client/$JENKINS_SWARM_VERSION/swarm-client-$JENKINS_SWARM_VERSION-jar-with-dependencies.jar
+
+USER root
+
+ADD ./jenkins-slave.sh /tmp/jenkins-slave.sh
+RUN chmod +x /tmp/jenkins-slave.sh
+ADD ./jenkins.service /etc/systemd/system/jenkins.service
 RUN systemctl enable jenkins.service
+
+#ENTRYPOINT ["/tmp/jenkins-slave.sh"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+NS = openmicroscopy
+VERSION ?= latest
+
+REPO = devslave-c7-docker
+NAME = devslave
+
+build:
+	docker build $(BUILDARGS) -t $(NS)/$(REPO):$(VERSION) .
+
+shell:
+	docker run --rm --name $(NAME) -i -t $(PORTS) $(VOLUMES) $(ENV) $(NS)/$(REPO):$(VERSION) /bin/bash
+
+run:
+	docker run --rm --name $(NAME) $(PORTS) $(VOLUMES) $(ENV) $(NS)/$(REPO):$(VERSION)
+
+start:
+	docker run -d --name $(NAME) $(PORTS) $(VOLUMES) $(ENV) $(NS)/$(REPO):$(VERSION)
+
+stop:
+	docker stop $(NAME)
+
+rm:
+	docker rm $(NAME)
+
+default: build
+
+.PHONY: build push shell run start stop rm release

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 NS = openmicroscopy
-VERSION ?= latest
+VERSION ?= local
 
-REPO = devslave-c7-docker
+REPO = devslave-c7
 NAME = devslave
 
 build:

--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+OMERO systemd Jenkins master and slave CI template
+=========================================
+
+Docker image for OMERO devspace.
+
+###  Docker
+
+1. Build container:
+
+        make build
+
+2. To run container
+
+        cd slave
+
+    - Unix:
+
+            make run
+
+    - OSX:
+
+            make run_osx
+
+The compose creates fully working Jenkins CI master and slave with full `sudo` rights. Jenkins swarm plugin is automatically started via systemd. Test Jenkins nodes via http://$(docker-machine ip dev):8080/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-OMERO systemd Jenkins master and slave CI template
-=========================================
+OMERO systemd Jenkins slave
+===========================
 
-Docker image for OMERO devspace.
+Docker Jenkins slave image for OMERO devspace.
 
 ###  Docker
 
@@ -12,10 +12,15 @@ Docker image for OMERO devspace.
     with args
 
         make BUILDARGS="--build-arg JAVAVER=$JAVAVER --build-arg EXE4J_VERSION=$EXE4J_VERSION --build-arg JENKINS_SWARM_VERSION=$JENKINS_SWARM_VERSION"
+
 2. To run container
 
-        make start VOLUME="-v /sys/fs/cgroup:/sys/fs/cgroup:ro -v /run"
+    UNIX:
 
-    NOTE: if you are using docker-machine use --privileged
+        make start ENV="-e JENKINS_PORT_8080_TCP_ADDR=$JENKINS_ADDR -e JENKINS_PORT_8080_TCP_PORT=$JENKINS_PORT" VOLUME="-v /sys/fs/cgroup:/sys/fs/cgroup:ro -v /run"
+
+    OSX:
+
+        make start PORTS="--privileged" ENV="-e JENKINS_PORT_8080_TCP_ADDR=$JENKINS_ADDR -e JENKINS_PORT_8080_TCP_PORT=$JENKINS_PORT"
 
 The compose creates fully working Jenkins CI master and slave with full `sudo` rights. Jenkins swarm plugin is automatically started via systemd. Test Jenkins nodes via http://$(docker-machine ip dev):8080/

--- a/README.md
+++ b/README.md
@@ -7,18 +7,15 @@ Docker image for OMERO devspace.
 
 1. Build container:
 
-        make build
+        make
 
+    with args
+
+        make BUILDARGS="--build-arg JAVAVER=$JAVAVER --build-arg EXE4J_VERSION=$EXE4J_VERSION --build-arg JENKINS_SWARM_VERSION=$JENKINS_SWARM_VERSION"
 2. To run container
 
-        cd slave
+        make start VOLUME="-v /sys/fs/cgroup:/sys/fs/cgroup:ro -v /run"
 
-    - Unix:
-
-            make run
-
-    - OSX:
-
-            make run_osx
+    NOTE: if you are using docker-machine use --privileged
 
 The compose creates fully working Jenkins CI master and slave with full `sudo` rights. Jenkins swarm plugin is automatically started via systemd. Test Jenkins nodes via http://$(docker-machine ip dev):8080/

--- a/README.md
+++ b/README.md
@@ -23,4 +23,4 @@ Docker Jenkins slave image for OMERO devspace.
 
         make start PORTS="--privileged" ENV="-e JENKINS_PORT_8080_TCP_ADDR=$JENKINS_ADDR -e JENKINS_PORT_8080_TCP_PORT=$JENKINS_PORT"
 
-The compose creates fully working Jenkins CI master and slave with full `sudo` rights. Jenkins swarm plugin is automatically started via systemd. Test Jenkins nodes via http://$(docker-machine ip dev):8080/
+The compose creates fully working Jenkins CI master and slave with full `sudo` rights. Jenkins swarm plugin is automatically started via systemd.

--- a/jenkins.service
+++ b/jenkins.service
@@ -1,15 +1,15 @@
 [Unit]
 Description=Jenkins slave
+Documentation=https://developer.cloudbees.com/bin/view/DEV/On-Premise+Executors
+After=multi-user.target
 
 [Service]
-User=omero
-WorkingDirectory=/tmp
-PIDFile=/tmp/jenkins.pid
-Type=forking
-Restart=on-failure
-RestartSec=10
+Type=simple
 ExecStart=/tmp/jenkins-slave.sh
-ExecStop=/usr/bin/bash -c 'test -e /tmp/jenkins.pid && kill $(cat jenkins.pid)'
+Restart=always
+RestartSec=60
+StartLimitInterval=0
+User=omero
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This PR improves slave node using systemd

To test it:
- deploy jenkins (use https://github.com/aleksandra-tarkowska/omero-ssh-systemd-jenkins-slave)
- attache to jenkins container to find out `env | grep JENKINS_PORT_8080_TCP`
- build using `make build`
- start container:
  
  ```
  UNIX: make start ENV="-e JENKINS_PORT_8080_TCP_ADDR=172.17.0.2 -e JENKINS_PORT_8080_TCP_PORT=8080" VOLUME="-v /sys/fs/cgroup:/sys/fs/cgroup:ro -v /run"
  ```
  
  ```
  OSX: make start PORTS="--privileged" ENV="-e JENKINS_PORT_8080_TCP_ADDR=172.17.0.2 -e JENKINS_PORT_8080_TCP_PORT=8080"
  ```
- jenkins logs will show:
  
  ```
  jenkins_1 | INFO: Accepted connection #2 from /172.17.0.4:43378
  ```
- attache to devslave:
  
  ```
  $ docker exec -it devslave bash -c "service jenkins status"
  service jenkins status                                                                                    Redirecting to /bin/systemctl status  jenkins.service    
  ● jenkins.service - Jenkins slave
  Loaded: loaded (/etc/systemd/system/jenkins.service; enabled; vendor preset: disabled)
  Active: active (running) since Thu 2016-04-07 21:14:02 UTC; 14min ago
   Docs: https://developer.cloudbees.com/bin/view/DEV/On-Premise+Executors
  Main PID: 223 (java)
   CGroup: /system.slice/jenkins.service
           └─223 java -jar /tmp/swarm-client-2.0-jar-with-dependencies.jar -fsroot /home/omero -master http://172.17.0.2:8080 -lab...
  
  Apr 07 21:14:02 cca03c032f77 jenkins-slave.sh[223]: Apr 07, 2016 9:14:02 PM hudson.remoting.jnlp.Main$CuiListener <init>
  Apr 07 21:14:02 cca03c032f77 jenkins-slave.sh[223]: INFO: Jenkins agent is running in headless mode.
  Apr 07 21:14:02 cca03c032f77 jenkins-slave.sh[223]: Apr 07, 2016 9:14:02 PM hudson.remoting.jnlp.Main$CuiListener status
  Apr 07 21:14:02 cca03c032f77 jenkins-slave.sh[223]: INFO: Locating server among [http://172.17.0.2:8080/]
  Apr 07 21:14:02 cca03c032f77 jenkins-slave.sh[223]: Apr 07, 2016 9:14:02 PM hudson.remoting.jnlp.Main$CuiListener status
  Apr 07 21:14:02 cca03c032f77 jenkins-slave.sh[223]: INFO: Connecting to 172.17.0.2:50000
  Apr 07 21:14:02 cca03c032f77 jenkins-slave.sh[223]: Apr 07, 2016 9:14:02 PM hudson.remoting.jnlp.Main$CuiListener status
  Apr 07 21:14:02 cca03c032f77 jenkins-slave.sh[223]: INFO: Handshaking
  Apr 07 21:14:02 cca03c032f77 jenkins-slave.sh[223]: Apr 07, 2016 9:14:02 PM hudson.remoting.jnlp.Main$CuiListener status
  Apr 07 21:14:02 cca03c032f77 jenkins-slave.sh[223]: INFO: Connected
  ```
- check jenkins http://jenkins:8080/computer/ if new node is up

cc: @joshmoore 
