### PR TITLE
Bump upstream Docker image to 0.1.1-1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openmicroscopy/omero-ssh-daemon-c7:0.1.1
+FROM openmicroscopy/omero-ssh-daemon-c7:0.1.1-1
 
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 


### PR DESCRIPTION
This should prevent yum install gcc to update glibc-common and affect the locale.