### PR TITLE
Upgrade swarm client plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,7 @@ services:
   - docker
 
 env:
-  - JAVAVER="openjdk17"
   - JAVAVER="openjdk18"
-  - JAVAVER="openjdk17-devel"
   - JAVAVER="openjdk18-devel"
 
 before_install:

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,10 +25,10 @@ ARG EXE4J_VERSION=${EXE4J_VERSION:-6_0}
 RUN yum install -y http://download-keycdn.ej-technologies.com/exe4j/exe4j_linux_$EXE4J_VERSION.rpm \
     && yum clean all
 
-ARG JENKINS_SWARM_VERSION=${JENKINS_SWARM_VERSION:-2.0}
+ARG JENKINS_SWARM_VERSION=${JENKINS_SWARM_VERSION:-3.14}
 
 USER omero
-RUN curl --create-dirs -sSLo /tmp/swarm-client-$JENKINS_SWARM_VERSION-jar-with-dependencies.jar https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/$JENKINS_SWARM_VERSION/swarm-client-$JENKINS_SWARM_VERSION-jar-with-dependencies.jar
+RUN curl --create-dirs -sSLo /tmp/swarm-client-$JENKINS_SWARM_VERSION-jar-with-dependencies.jar https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/$JENKINS_SWARM_VERSION/swarm-client.jar
 
 USER root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENV OMERO_INSTALL /tmp/omero-install/linux
 RUN yum install -y git \
     && yum clean all
 
-ARG TAG=v5.3.3
+ARG TAG=v5.4.8
 RUN git clone -b $TAG https://github.com/ome/omero-install.git /tmp/omero-install
 RUN bash $OMERO_INSTALL/step01_centos7_init.sh
 RUN bash $OMERO_INSTALL/step01_centos_java_deps.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN yum install -y http://download-keycdn.ej-technologies.com/exe4j/exe4j_linux_
 ARG JENKINS_SWARM_VERSION=${JENKINS_SWARM_VERSION:-3.14}
 
 USER omero
-RUN curl --create-dirs -sSLo /tmp/swarm-client-$JENKINS_SWARM_VERSION-jar-with-dependencies.jar https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/$JENKINS_SWARM_VERSION/swarm-client.jar
+RUN curl --create-dirs -sSLo /tmp/swarm-client-$JENKINS_SWARM_VERSION.jar https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/$JENKINS_SWARM_VERSION/swarm-client.jar
 
 USER root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN yum install -y http://download-keycdn.ej-technologies.com/exe4j/exe4j_linux_
 ARG JENKINS_SWARM_VERSION=${JENKINS_SWARM_VERSION:-3.14}
 
 USER omero
-RUN curl --create-dirs -sSLo /tmp/swarm-client-$JENKINS_SWARM_VERSION.jar https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/$JENKINS_SWARM_VERSION/swarm-client.jar
+RUN curl --create-dirs -sSLo /tmp/swarm-client-$JENKINS_SWARM_VERSION.jar https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/$JENKINS_SWARM_VERSION/swarm-client-$JENKINS_SWARM_VERSION.jar
 
 USER root
 

--- a/jenkins-slave.sh
+++ b/jenkins-slave.sh
@@ -6,7 +6,7 @@
 if [[ $# -lt 1 ]] || [[ "$1" == "-"* ]]; then
 
   # jenkins swarm slave
-  JAR=`ls -1 /tmp/swarm-client.jar | tail -n 1`
+  JAR=`ls -1 /tmp/swarm-client-*.jar | tail -n 1`
 
   PARAMS=""
   if [ ! -z "$JENKINS_USERNAME" ]; then

--- a/jenkins-slave.sh
+++ b/jenkins-slave.sh
@@ -6,7 +6,7 @@
 if [[ $# -lt 1 ]] || [[ "$1" == "-"* ]]; then
 
   # jenkins swarm slave
-  JAR=`ls -1 /tmp/swarm-client-*.jar | tail -n 1`
+  JAR=`ls -1 /tmp/swarm-client.jar | tail -n 1`
 
   PARAMS=""
   if [ ! -z "$JENKINS_USERNAME" ]; then


### PR DESCRIPTION
With Jenkins LTS 2.138.1, some of the deprecated protocols are disabled. For our Docker-based images using the Swarm Client plugin, the [Remoting upgrade](https://jenkins.io/doc/upgrade-guide/2.121/#remoting-update) recommendation is to upgrade to version 3.11 or above. As version 3.7 of the Swarm Plugin Client requires Java 8 as a minimum, `openjdk17{-devel}` are removed from the Travis matrix.

The version of `omero-install` is also updated to 5.4.8.

Proposed tag: `0.5.0`